### PR TITLE
Configure Http reporter with $agentHost

### DIFF
--- a/Factory/ZipkinTracerFactory.php
+++ b/Factory/ZipkinTracerFactory.php
@@ -45,7 +45,7 @@ final class ZipkinTracerFactory implements TracerFactory
         try {
             $this->agentHostResolver->ensureAgentHostIsResolvable($agentHost);
             $endpoint = Endpoint::create($projectName, gethostbyname($agentHost), null, (int) $agentPort);
-            $reporter = new Http();
+            $reporter = $this->createReporter($endpoint);
             $samplerValue = json_decode($samplerValue);
             $sampler = $this->samplerFactory->createSampler($samplerClass, $samplerValue);
             $tracing = TracingBuilder::create()
@@ -60,5 +60,18 @@ final class ZipkinTracerFactory implements TracerFactory
         }
 
         return $tracer;
+    }
+
+    /**
+     * @param Endpoint $endpoint
+     * @return Http
+     */
+    private function createReporter(Endpoint $endpoint): Http
+    {
+        return new Http(
+            [
+                'endpoint_url' => sprintf('http://%s:%d/api/v2/spans', $endpoint->getIpv4(), $endpoint->getPort()),
+            ]
+        );
     }
 }

--- a/Tests/Factory/ZipkinTracerFactoryTest.php
+++ b/Tests/Factory/ZipkinTracerFactoryTest.php
@@ -134,12 +134,20 @@ class ZipkinTracerFactoryTest extends TestCase
     private function extractReporterOptionsByReflection(\OpenTracing\Tracer $tracer)
     {
         $tracerRef = new \ReflectionClass($tracer);
-        $ottTracer = $tracerRef->getProperty('tracer')->getValue($tracer);
+        $tracerProperty = $tracerRef->getProperty('tracer');
+        $tracerProperty->setAccessible(true);
+        $ottTracer = $tracerProperty->getValue($tracer);
         $ottTracerRef = new \ReflectionClass($ottTracer);
-        $recorder = $ottTracerRef->getProperty('recorder')->getValue($ottTracer);
+        $recorderProperty = $ottTracerRef->getProperty('recorder');
+        $recorderProperty->setAccessible(true);
+        $recorder = $recorderProperty->getValue($ottTracer);
         $recorderRef = new \ReflectionClass($recorder);
-        $reporter = $recorderRef->getProperty('reporter')->getValue($recorder);
+        $reporterProperty = $recorderRef->getProperty('reporter');
+        $reporterProperty->setAccessible(true);
+        $reporter = $reporterProperty->getValue($recorder);
         $reporterRef = new \ReflectionClass($reporter);
-        return $reporterRef->getProperty('options')->getValue($reporter);
+        $optionsProperty = $reporterRef->getProperty('options');
+        $optionsProperty->setAccessible(true);
+        return $optionsProperty->getValue($reporter);
     }
 }

--- a/Tests/Factory/ZipkinTracerFactoryTest.php
+++ b/Tests/Factory/ZipkinTracerFactoryTest.php
@@ -13,7 +13,6 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
-use Zipkin\Recorder;
 use Zipkin\Samplers\BinarySampler;
 use ZipkinOpenTracing\Tracer;
 


### PR DESCRIPTION
While preparing a docker-compose setup I recognized that no samples have been sent to my zipkin container (not localhost), so I started debugging and found out, that the `\Zipkin\Reporters\Http` has a default `'endpoint_url'` pointing to localhost and the `\Auxmoney\OpentracingBundle\Factory\ZipkinTracerFactory` won't set the proper values.

